### PR TITLE
Adds a ClientRateLimitPlugin to limit the number of requests the client makes for a given period.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ using it is as simple as adding a single line to Gradle.
 ##### Gradle
 
 ```kotlin
-implementation("org.audux.bgg:bggclient:0.9.4")
+implementation("org.audux.bgg:bggclient:1.0.0")
 ```
 
 ##### Maven
@@ -35,7 +35,7 @@ implementation("org.audux.bgg:bggclient:0.9.4")
 <dependency>
     <groupId>org.audux.bgg</groupId>
     <artifactId>bggclient</artifactId>
-    <version>0.9.4</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 
@@ -175,12 +175,15 @@ Data contains a (multi) map of types and URLs (`Map<SitemapLocationType, List<Si
 
 `BggClientConfiguration` allows the client to be configured differently. This allows the user to
 increase the maximum number of retries, the maximum number of concurrent requests and how the
-exponential delay is calculated.
+exponential delay is calculated. The below example also configured (The already default) request 
+limit to 60 request per minute - this appears to be the BGG limit.
 
 ```kotlin
 BggClient.configure {
     maxConcurrentRequests = 5
     maxRetries = 100
+    requestsPerWindowLimit = 60
+    requestWindowSize = 60.seconds
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "org.audux.bgg"
             artifactId = "bggclient"
-            version = "0.9.4"
+            version = "0.9.5"
 
             pom {
                 name = "Unofficial JVM BGG client"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "org.audux.bgg"
             artifactId = "bggclient"
-            version = "0.9.5"
+            version = "1.0.0"
 
             pom {
                 name = "Unofficial JVM BGG client"

--- a/examples/android/app/build.gradle.kts
+++ b/examples/android/app/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
     implementation("io.coil-kt:coil-compose:2.5.0")
-    implementation("org.audux.bgg:bggclient:0.9.4")
+    implementation("org.audux.bgg:bggclient:1.0.0")
 
     testImplementation("junit:junit:4.13.2")
 

--- a/examples/java/build.gradle.kts
+++ b/examples/java/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.audux.bgg:bggclient:0.9.4")
+    implementation("org.audux.bgg:bggclient:1.0.0")
 
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/examples/paginate/build.gradle.kts
+++ b/examples/paginate/build.gradle.kts
@@ -20,7 +20,7 @@ application {
 }
 
 dependencies {
-    implementation("org.audux.bgg:bggclient:0.9.4")
+    implementation("org.audux.bgg:bggclient:1.0.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
 com-gradleup-nmcp = "0.0.8"
-jackson = "2.17.1"
-javax-xml-stream = "1.0-2"
-junit5 = "5.10.2"
-kermit = "2.0.3"
-ktfmt-gradle = "0.18.0"
-ktor = "2.3.11"
+jackson = "2.18.0"
+jakarta-xml-binding = "4.0.2"
+junit5 = "5.11.3"
+kermit = "2.0.4"
+ktfmt-gradle = "0.20.1"
+ktor = "2.3.12"
 org-jetbrains-dokka = "1.9.20"
 org-jetbrains-kotlin-jdk8 = "1.8.1"
 org-jetbrains-kotlin-jvm = "2.0.0"
 serialization = "1.6.3"
-slf4j = "2.0.13"
-truth = "1.4.2"
+slf4j = "2.0.16"
+truth = "1.4.4"
 
 [libraries]
 jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
-javax-xml-stream = { module = "javax.xml.stream:stax-api", version.ref = "javax-xml-stream" }
+javax-xml-stream = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakarta-xml-binding" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit5-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }

--- a/src/main/kotlin/org/audux/bgg/BggClient.kt
+++ b/src/main/kotlin/org/audux/bgg/BggClient.kt
@@ -17,6 +17,8 @@ import co.touchlab.kermit.Logger
 import io.ktor.client.engine.cio.CIO
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import org.audux.bgg.common.Domain
 import org.audux.bgg.common.FamilyType
 import org.audux.bgg.common.ForumListType
@@ -211,7 +213,7 @@ object BggClient {
         minimumPlays: Int? = null,
         maxPlays: Int? = null,
         collectionId: Int? = null,
-        modifiedSince: LocalDateTime? = null
+        modifiedSince: LocalDateTime? = null,
     ) =
         InternalBggClient()
             .collection(
@@ -243,7 +245,7 @@ object BggClient {
                 minimumPlays,
                 maxPlays,
                 collectionId,
-                modifiedSince
+                modifiedSince,
             )
 
     /**
@@ -580,11 +582,8 @@ object BggClient {
      */
     @JvmStatic
     @JvmOverloads
-    fun search(
-        query: String,
-        types: Array<ThingType> = arrayOf(),
-        exactMatch: Boolean = false,
-    ) = InternalBggClient().search(query, types, exactMatch)
+    fun search(query: String, types: Array<ThingType> = arrayOf(), exactMatch: Boolean = false) =
+        InternalBggClient().search(query, types, exactMatch)
 
     /**
      * Requests the Sitemap index for the given Domain. Call
@@ -775,7 +774,7 @@ object BggClient {
                 comments,
                 ratingComments,
                 page,
-                pageSize
+                pageSize,
             )
 
     /**
@@ -831,7 +830,7 @@ object BggClient {
         id: Int,
         minArticleId: Int? = null,
         minArticleDate: LocalDateTime? = null,
-        count: Int? = null
+        count: Int? = null,
     ) = InternalBggClient().thread(id, minArticleId, minArticleDate, count)
 
     /**
@@ -922,7 +921,7 @@ object BggClient {
         Debug,
         Info,
         Warn,
-        Error
+        Error,
     }
 
     /** Sets the Logger severity defaults to [Severity.Error] */
@@ -956,6 +955,10 @@ object BggClient {
  * @property requestTimeoutMillis At which point requests time out/throw an time out Exception.
  * @property failOnUnknownProperties whether BGGClient should fail when it encounters unknown
  *   properties or if it should parse what it can for the given api.
+ * @property requestsPerWindowLimit Throttles the client to have [requestsPerWindowLimit] request
+ *   per [requestWindowSize], e.g. "60 requests per 60.seconds".
+ * @property requestWindowSize Throttles the client to have [requestsPerWindowLimit] request per
+ *   [requestWindowSize], e.g. "60 requests per 60.seconds".
  */
 data class BggClientConfiguration(
     var maxConcurrentRequests: Int = 10,
@@ -965,6 +968,8 @@ data class BggClientConfiguration(
     var retryRandomizationMs: Long = 1_000,
     var requestTimeoutMillis: Long = 15_000,
     var failOnUnknownProperties: Boolean = true,
+    var requestsPerWindowLimit: Int = 60,
+    var requestWindowSize: Duration = 60.seconds,
 )
 
 /** Thrown whenever any exception is thrown during a request to BGG. */

--- a/src/main/kotlin/org/audux/bgg/common/Types.kt
+++ b/src/main/kotlin/org/audux/bgg/common/Types.kt
@@ -59,7 +59,7 @@ enum class HotListType(val param: String) {
     RPG_COMPANY("rpgcompany"), // Does not actually work?
     RPG_PERSON("rpgperson"), // Does not actually work?
     VIDEO_GAME("videogame"), // Does not actually work?
-    VIDEO_GAME_COMPANY("videogamecompany") // Does not actually work?
+    VIDEO_GAME_COMPANY("videogamecompany"), // Does not actually work?
 }
 
 /** Different sub types returned in the [org.audux.bgg.request.plays] request/ response */

--- a/src/main/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPlugin.kt
+++ b/src/main/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPlugin.kt
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2023-2024 Bram Wijnands
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.audux.bgg.plugin
+
+import co.touchlab.kermit.Logger
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.delay
+import org.jetbrains.annotations.Contract
+import org.jetbrains.annotations.VisibleForTesting
+
+/**
+ * Ktor plugin to configure the client to limit the number of concurrent requests it can make.
+ * Additional requests will be canceled and re-queued to be send whenever another request has been
+ * completed.
+ */
+internal val ClientConcurrentRateLimitPlugin =
+    createClientPlugin(
+        "ClientConcurrentRateLimitPlugin",
+        createConfiguration = ::ConcurrentRequestLimiterConfiguration,
+    ) {
+        val requestLimiter = ConcurrentRequestLimiter(pluginConfig.requestLimit)
+        onRequest { request, _ -> requestLimiter.onNewRequest(request) }
+    }
+
+/**
+ * Implementation of [ClientConcurrentRateLimitPlugin] ensuring not more than
+ * [ConcurrentRequestLimiterConfiguration.requestLimit] are being made concurrently.
+ */
+internal class ConcurrentRequestLimiter(private val requestLimit: Int) {
+    internal val inFlightRequests = AtomicSingletonInteger.instance
+
+    /**
+     * Keeps an counter for the number of requests that are active/in-flight. If ever the limit is
+     * reached the request is held indefinitely until this request or other requests are
+     * completed/cancelled.
+     *
+     * Called on [io.ktor.client.plugins.api.ClientPluginBuilder.onRequest].
+     */
+    suspend fun onNewRequest(request: HttpRequestBuilder) {
+        logger.v(tag = "ConcurrentRequestLimiter") { "#OnNewRequest()" }
+        // Ensure inFlight requests count is decremented whenever a request [Job] completes.
+        request.executionContext.invokeOnCompletion {
+            logger.v(tag = "ConcurrentRequestLimiter") { "Request completed" }
+            inFlightRequests.decrementAndGet()
+        }
+
+        // Check whether the `inFlightRequests` count has been reached, if so delay and check again.
+        do {
+            val currentInFlightRequests = inFlightRequests.get()
+            if (currentInFlightRequests < requestLimit) {
+                inFlightRequests.incrementAndGet()
+                break
+            }
+
+            logger.v(tag = "ConcurrentRequestLimiter") {
+                "Concurrent Requests limit reached[$currentInFlightRequests/$requestLimit]"
+            }
+
+            // Delay and yield as we've reached the concurrent request limit.
+            delay(IDLING_DELAY)
+        } while (true)
+    }
+
+    companion object {
+        private val logger = Logger.withTag("ClientRateLimitPlugin")
+        private const val IDLING_DELAY = 50L
+    }
+}
+
+/**
+ * Configuration for the concurrent request limiter.
+ *
+ * @property requestLimit The maximum number of concurrent requests that can be made.
+ */
+internal data class ConcurrentRequestLimiterConfiguration(var requestLimit: Int = 10)
+
+/**
+ * Singleton [AtomicInteger] to be shared between [org.audux.bgg.BggClient] instances as a new
+ * instance of the plugin is created for each client.
+ */
+internal class AtomicSingletonInteger
+@Contract(pure = true)
+private constructor(initialValue: Int) : AtomicInteger(initialValue) {
+    companion object {
+        val instance: AtomicSingletonInteger by lazy { AtomicSingletonInteger(0) }
+    }
+
+    /** Clears the in-flight requests counter. */
+    @VisibleForTesting fun reset() = this.set(0)
+
+    override fun toByte() = get().toByte()
+
+    override fun toShort() = get().toShort()
+}

--- a/src/main/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPlugin.kt
+++ b/src/main/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPlugin.kt
@@ -18,8 +18,6 @@ import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.HttpRequestBuilder
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.delay
-import org.jetbrains.annotations.Contract
-import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * Ktor plugin to configure the client to limit the number of concurrent requests it can make.
@@ -40,7 +38,7 @@ internal val ClientConcurrentRateLimitPlugin =
  * [ConcurrentRequestLimiterConfiguration.requestLimit] are being made concurrently.
  */
 internal class ConcurrentRequestLimiter(private val requestLimit: Int) {
-    internal val inFlightRequests = AtomicSingletonInteger.instance
+    internal val inFlightRequests = AtomicInteger()
 
     /**
      * Keeps an counter for the number of requests that are active/in-flight. If ever the limit is
@@ -86,22 +84,3 @@ internal class ConcurrentRequestLimiter(private val requestLimit: Int) {
  * @property requestLimit The maximum number of concurrent requests that can be made.
  */
 internal data class ConcurrentRequestLimiterConfiguration(var requestLimit: Int = 10)
-
-/**
- * Singleton [AtomicInteger] to be shared between [org.audux.bgg.BggClient] instances as a new
- * instance of the plugin is created for each client.
- */
-internal class AtomicSingletonInteger
-@Contract(pure = true)
-private constructor(initialValue: Int) : AtomicInteger(initialValue) {
-    companion object {
-        val instance: AtomicSingletonInteger by lazy { AtomicSingletonInteger(0) }
-    }
-
-    /** Clears the in-flight requests counter. */
-    @VisibleForTesting fun reset() = this.set(0)
-
-    override fun toByte() = get().toByte()
-
-    override fun toShort() = get().toShort()
-}

--- a/src/main/kotlin/org/audux/bgg/plugin/ClientRateLimitPlugin.kt
+++ b/src/main/kotlin/org/audux/bgg/plugin/ClientRateLimitPlugin.kt
@@ -16,16 +16,15 @@ package org.audux.bgg.plugin
 import co.touchlab.kermit.Logger
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.HttpRequestBuilder
-import kotlinx.coroutines.delay
-import org.jetbrains.annotations.VisibleForTesting
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * Ktor client rate limit plugin.
@@ -34,57 +33,57 @@ import kotlin.time.TimeSource
  * example the plugin can be configured to do 60 requests per minute, or 1 request per second etc.
  */
 internal val ClientRateLimitPlugin =
-  createClientPlugin(
-    "ClientRateLimitPlugin",
-    createConfiguration = ::RequestLimiterConfiguration,
-  ) {
-    val requestLimiter = RequestLimiter(pluginConfig.requestLimit, pluginConfig.windowSize)
-    onRequest { request, _ -> requestLimiter.onNewRequest(request) }
-  }
+    createClientPlugin(
+        "ClientRateLimitPlugin",
+        createConfiguration = ::RequestLimiterConfiguration,
+    ) {
+        val requestLimiter = RequestLimiter(pluginConfig.requestLimit, pluginConfig.windowSize)
+        onRequest { request, _ -> requestLimiter.onNewRequest(request) }
+    }
 
 /**
  * Implementation of [ClientRateLimitPlugin] ensuring not more than [requestLimit] are being within
  * the period of [windowLength].
  */
 internal class RequestLimiter(private val requestLimit: Int, private val windowLength: Duration) {
-  private val timeSource: TimeSource = TimeSource.Monotonic
-  private var currentWindowStart: AtomicReference<TimeMark?> = AtomicReference()
-  private var requestsInDelayed: AtomicInteger = AtomicInteger(0)
+    private val timeSource: TimeSource = TimeSource.Monotonic
+    private var currentWindowStart: AtomicReference<TimeMark?> = AtomicReference()
+    private var requestsInDelayed: AtomicInteger = AtomicInteger(0)
 
-  @VisibleForTesting
-  internal var requestsInCurrentWindow: AtomicInteger = AtomicInteger(0)
+    @VisibleForTesting internal var requestsInCurrentWindow: AtomicInteger = AtomicInteger(0)
 
-  suspend fun onNewRequest(request: HttpRequestBuilder) {
-    do {
-      var windowStart = currentWindowStart.get()
-      if (windowStart == null || windowStart.plus(windowLength).hasPassedNow()) {
-        windowStart = timeSource.markNow()
-        currentWindowStart.set(windowStart)
-        requestsInCurrentWindow.set(0)
-      }
+    suspend fun onNewRequest(request: HttpRequestBuilder) {
+        do {
+            var windowStart = currentWindowStart.get()
+            if (windowStart == null || windowStart.plus(windowLength).hasPassedNow()) {
+                windowStart = timeSource.markNow()
+                currentWindowStart.set(windowStart)
+                requestsInCurrentWindow.set(0)
+            }
 
-      val requestsMadeInWindow = requestsInCurrentWindow.get()
-      if (requestsMadeInWindow < requestLimit) {
-        requestsInCurrentWindow.incrementAndGet()
-        break
-      }
+            val requestsMadeInWindow = requestsInCurrentWindow.get()
+            if (requestsMadeInWindow < requestLimit) {
+                requestsInCurrentWindow.incrementAndGet()
+                break
+            }
 
-      val requestsBeingDelayed = requestsInDelayed.incrementAndGet()
-      logger.i(tag = "RequestLimiter") {
-        "Requests limit for window reached[$requestsMadeInWindow/$requestLimit]"
-      }
+            val requestsBeingDelayed = requestsInDelayed.incrementAndGet()
+            logger.i(tag = "RequestLimiter") {
+                "Requests limit for window reached[$requestsMadeInWindow/$requestLimit]"
+            }
 
-      // Add `requestsBeingDelayed`ms to the delay to ensure requests retain order after delay.
-      delay(
-        windowLength.minus(windowStart.elapsedNow()).plus(requestsBeingDelayed.milliseconds)
-      )
-      requestsBeingDelayed.dec()
-    } while (true)
-  }
+            // Add `requestsBeingDelayed`ms to the delay to ensure requests retain order after
+            // delay.
+            delay(
+                windowLength.minus(windowStart.elapsedNow()).plus(requestsBeingDelayed.milliseconds)
+            )
+            requestsBeingDelayed.dec()
+        } while (true)
+    }
 
-  companion object {
-    private val logger = Logger.withTag("ClientRateLimitPlugin")
-  }
+    companion object {
+        private val logger = Logger.withTag("ClientRateLimitPlugin")
+    }
 }
 
 /**
@@ -96,6 +95,6 @@ internal class RequestLimiter(private val requestLimit: Int, private val windowL
  *   "60 requests per 60.seconds".
  */
 internal data class RequestLimiterConfiguration(
-  var requestLimit: Int = 60,
-  var windowSize: Duration = 60.seconds,
+    var requestLimit: Int = 60,
+    var windowSize: Duration = 60.seconds,
 )

--- a/src/main/kotlin/org/audux/bgg/plugin/ClientRateLimitPlugin.kt
+++ b/src/main/kotlin/org/audux/bgg/plugin/ClientRateLimitPlugin.kt
@@ -16,14 +16,16 @@ package org.audux.bgg.plugin
 import co.touchlab.kermit.Logger
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.HttpRequestBuilder
+import kotlinx.coroutines.delay
+import org.jetbrains.annotations.VisibleForTesting
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
-import kotlinx.coroutines.delay
-import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * Ktor client rate limit plugin.
@@ -32,50 +34,57 @@ import org.jetbrains.annotations.VisibleForTesting
  * example the plugin can be configured to do 60 requests per minute, or 1 request per second etc.
  */
 internal val ClientRateLimitPlugin =
-    createClientPlugin(
-        "ClientRateLimitPlugin",
-        createConfiguration = ::RequestLimiterConfiguration,
-    ) {
-        val requestLimiter = RequestLimiter(pluginConfig.requestLimit, pluginConfig.windowSize)
-        onRequest { request, _ -> requestLimiter.onNewRequest(request) }
-    }
+  createClientPlugin(
+    "ClientRateLimitPlugin",
+    createConfiguration = ::RequestLimiterConfiguration,
+  ) {
+    val requestLimiter = RequestLimiter(pluginConfig.requestLimit, pluginConfig.windowSize)
+    onRequest { request, _ -> requestLimiter.onNewRequest(request) }
+  }
 
 /**
  * Implementation of [ClientRateLimitPlugin] ensuring not more than [requestLimit] are being within
  * the period of [windowLength].
  */
 internal class RequestLimiter(private val requestLimit: Int, private val windowLength: Duration) {
-    private val timeSource: TimeSource = TimeSource.Monotonic
-    private var currentWindowStart: AtomicReference<TimeMark?> = AtomicReference()
+  private val timeSource: TimeSource = TimeSource.Monotonic
+  private var currentWindowStart: AtomicReference<TimeMark?> = AtomicReference()
+  private var requestsInDelayed: AtomicInteger = AtomicInteger(0)
 
-    @VisibleForTesting internal var requestsInCurrentWindow: AtomicInteger = AtomicInteger(0)
+  @VisibleForTesting
+  internal var requestsInCurrentWindow: AtomicInteger = AtomicInteger(0)
 
-    suspend fun onNewRequest(request: HttpRequestBuilder) {
-        var windowStart = currentWindowStart.get()
-        if (windowStart == null || windowStart.plus(windowLength).hasPassedNow()) {
-            windowStart = timeSource.markNow()
-            currentWindowStart.set(windowStart)
-        }
-        logger.v(tag = "RequestLimiter") { "#OnNewRequest()" }
+  suspend fun onNewRequest(request: HttpRequestBuilder) {
+    do {
+      var windowStart = currentWindowStart.get()
+      if (windowStart == null || windowStart.plus(windowLength).hasPassedNow()) {
+        windowStart = timeSource.markNow()
+        currentWindowStart.set(windowStart)
+        requestsInCurrentWindow.set(0)
+      }
 
-        val requestsMadeInWindow = requestsInCurrentWindow.get()
-        if (requestsMadeInWindow < requestLimit) {
-            requestsInCurrentWindow.incrementAndGet()
-        } else {
-            logger.i(tag = "RequestLimiter") {
-                "Requests limit for window reached[$requestsMadeInWindow/$requestLimit]"
-            }
+      val requestsMadeInWindow = requestsInCurrentWindow.get()
+      if (requestsMadeInWindow < requestLimit) {
+        requestsInCurrentWindow.incrementAndGet()
+        break
+      }
 
-            delay(windowLength.minus(windowStart.elapsedNow()))
-            logger.v(tag = "RequestLimiter") {
-                "Delay completed ${windowStart.elapsedNow().inWholeMilliseconds}"
-            }
-        }
-    }
+      val requestsBeingDelayed = requestsInDelayed.incrementAndGet()
+      logger.i(tag = "RequestLimiter") {
+        "Requests limit for window reached[$requestsMadeInWindow/$requestLimit]"
+      }
 
-    companion object {
-        private val logger = Logger.withTag("ClientRateLimitPlugin")
-    }
+      // Add `requestsBeingDelayed`ms to the delay to ensure requests retain order after delay.
+      delay(
+        windowLength.minus(windowStart.elapsedNow()).plus(requestsBeingDelayed.milliseconds)
+      )
+      requestsBeingDelayed.dec()
+    } while (true)
+  }
+
+  companion object {
+    private val logger = Logger.withTag("ClientRateLimitPlugin")
+  }
 }
 
 /**
@@ -87,6 +96,6 @@ internal class RequestLimiter(private val requestLimit: Int, private val windowL
  *   "60 requests per 60.seconds".
  */
 internal data class RequestLimiterConfiguration(
-    var requestLimit: Int = 60,
-    var windowSize: Duration = 60.seconds,
+  var requestLimit: Int = 60,
+  var windowSize: Duration = 60.seconds,
 )

--- a/src/main/kotlin/org/audux/bgg/request/DiffusingSitemap.kt
+++ b/src/main/kotlin/org/audux/bgg/request/DiffusingSitemap.kt
@@ -20,7 +20,7 @@ import org.audux.bgg.response.SitemapUrl
 class DiffusingSitemap
 internal constructor(
     private val client: InternalBggClient,
-    private val request: suspend () -> Response<SitemapIndex>
+    private val request: suspend () -> Response<SitemapIndex>,
 ) : Request<SitemapIndex>(client, request) {
 
     /**

--- a/src/main/kotlin/org/audux/bgg/request/Guild.kt
+++ b/src/main/kotlin/org/audux/bgg/request/Guild.kt
@@ -28,12 +28,7 @@ import org.audux.bgg.response.Guild
 import org.audux.bgg.response.Response
 
 /** @see org.audux.bgg.BggClient.guild */
-internal fun InternalBggClient.guild(
-    id: Int,
-    members: Inclusion?,
-    sort: String?,
-    page: Int?,
-) =
+internal fun InternalBggClient.guild(id: Int, members: Inclusion?, sort: String?, page: Int?) =
     PaginatedGuilds(this, members, sort) {
         client()
             .get(XML2_API_URL) {

--- a/src/main/kotlin/org/audux/bgg/request/PaginatedRequests.kt
+++ b/src/main/kotlin/org/audux/bgg/request/PaginatedRequests.kt
@@ -89,7 +89,7 @@ class PaginatedForum
 internal constructor(
     private val client: InternalBggClient,
     private val currentPage: Int,
-    private val request: suspend () -> Response<Forum>
+    private val request: suspend () -> Response<Forum>,
 ) : PaginatedRequest<Forum>(client, request) {
     /** @suppress */
     companion object {
@@ -134,7 +134,7 @@ internal constructor(
     private val client: InternalBggClient,
     private val members: Inclusion?,
     private val sort: String?,
-    private val request: suspend () -> Response<Guild>
+    private val request: suspend () -> Response<Guild>,
 ) : PaginatedRequest<Guild>(client, request) {
     /** @suppress */
     companion object {
@@ -172,7 +172,7 @@ internal constructor(
                                     id = guild.data.id,
                                     page = page,
                                     members = members,
-                                    sort = sort
+                                    sort = sort,
                                 )
                                 .call()
 
@@ -207,7 +207,7 @@ internal constructor(
     private val minDate: LocalDate?,
     private val maxDate: LocalDate?,
     private val subType: SubType?,
-    private val request: suspend () -> Response<Plays>
+    private val request: suspend () -> Response<Plays>,
 ) : PaginatedRequest<Plays>(client, request) {
     /** @suppress */
     companion object {
@@ -264,7 +264,7 @@ internal constructor(
     private val pageSize: Int,
     private val comments: Boolean,
     private val ratingComments: Boolean,
-    private val request: suspend () -> Response<Things>
+    private val request: suspend () -> Response<Things>,
 ) : PaginatedRequest<Things>(client, request) {
     override fun paginate(toPage: Int) =
         Request(client) {
@@ -296,7 +296,7 @@ internal constructor(
                                 page = page,
                                 pageSize = pageSize,
                                 comments = comments,
-                                ratingComments = ratingComments
+                                ratingComments = ratingComments,
                             )
                             .call()
 
@@ -319,7 +319,7 @@ internal constructor(
                                                 page = lastPage,
                                                 comments =
                                                     existingThing.comments.comments +
-                                                        newThing.comments.comments
+                                                        newThing.comments.comments,
                                             )
                                     )
                             }
@@ -417,13 +417,10 @@ internal constructor(
                             buddies =
                                 user.data.buddies?.copy(
                                     page = lastPage,
-                                    buddies = allBuddies.toList()
+                                    buddies = allBuddies.toList(),
                                 ),
                             guilds =
-                                user.data.guilds?.copy(
-                                    page = lastPage,
-                                    guilds = allGuilds.toList()
-                                ),
+                                user.data.guilds?.copy(page = lastPage, guilds = allGuilds.toList()),
                         )
                 )
             }
@@ -436,7 +433,7 @@ internal constructor(
  */
 internal suspend inline fun <T> concurrentRequests(
     pages: IntRange,
-    crossinline request: suspend (page: Int) -> T
+    crossinline request: suspend (page: Int) -> T,
 ) {
     val jobs = CopyOnWriteArrayList<Job>()
     runBlocking {

--- a/src/main/kotlin/org/audux/bgg/request/Request.kt
+++ b/src/main/kotlin/org/audux/bgg/request/Request.kt
@@ -20,7 +20,7 @@ import org.audux.bgg.response.Response
 open class Request<T>
 internal constructor(
     private val client: InternalBggClient,
-    private val request: suspend () -> Response<T>
+    private val request: suspend () -> Response<T>,
 ) {
     /**
      * Execute the encapsulated [T] request asynchronously and returns the `response` in the

--- a/src/main/kotlin/org/audux/bgg/request/Things.kt
+++ b/src/main/kotlin/org/audux/bgg/request/Things.kt
@@ -53,7 +53,7 @@ internal fun InternalBggClient.things(
         currentPage = page,
         pageSize = pageSize ?: 100,
         comments = comments,
-        ratingComments = ratingComments
+        ratingComments = ratingComments,
     ) {
         if (pageSize != null && !(10..100).contains(pageSize)) {
             throw BggRequestException("pageSize must be between 10 and 100")

--- a/src/main/kotlin/org/audux/bgg/response/Collection.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Collection.kt
@@ -40,7 +40,7 @@ data class Collection(
     @JacksonXmlProperty(isAttribute = true, localName = "pubdate") val publishDate: String,
 
     /** List of the actual things. */
-    @JacksonXmlProperty(localName = "item") val items: List<CollectionItem>
+    @JacksonXmlProperty(localName = "item") val items: List<CollectionItem>,
 )
 
 /** An item in the collection e.g. a board game, rpg etc. */

--- a/src/main/kotlin/org/audux/bgg/response/Family.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Family.kt
@@ -29,7 +29,7 @@ data class Family(
     @JacksonXmlProperty(isAttribute = true) val termsOfUse: String,
 
     /** List of the actual items. */
-    @JacksonXmlProperty(localName = "item") val items: List<FamilyItem>
+    @JacksonXmlProperty(localName = "item") val items: List<FamilyItem>,
 )
 
 /** The actual Family item e.g. a `boardgamefamily`, rpg etc. */
@@ -53,5 +53,5 @@ data class FamilyItem(
      * List of the items that are part of this family, e.g. board games that have a certain theme or
      * gameplay.
      */
-    @JacksonXmlProperty(localName = "link") val links: List<Link>
+    @JacksonXmlProperty(localName = "link") val links: List<Link>,
 )

--- a/src/main/kotlin/org/audux/bgg/response/ForumList.kt
+++ b/src/main/kotlin/org/audux/bgg/response/ForumList.kt
@@ -37,7 +37,7 @@ data class ForumList(
     val type: ForumListType,
 
     /** List of the actual available forums. */
-    @JacksonXmlProperty(localName = "forum") val forums: List<ForumSummary>
+    @JacksonXmlProperty(localName = "forum") val forums: List<ForumSummary>,
 )
 
 /**

--- a/src/main/kotlin/org/audux/bgg/response/GeekList.kt
+++ b/src/main/kotlin/org/audux/bgg/response/GeekList.kt
@@ -62,7 +62,7 @@ data class GeekList(
     val description: String,
 
     /** The actual items in the geek list e.g. a list of board games. */
-    @JacksonXmlProperty(localName = "item") val items: List<GeekListItem>
+    @JacksonXmlProperty(localName = "item") val items: List<GeekListItem>,
 ) {
     /** The list of comments of this list, only set if set to include in the request. */
     @JsonProperty("comment")

--- a/src/main/kotlin/org/audux/bgg/response/HotList.kt
+++ b/src/main/kotlin/org/audux/bgg/response/HotList.kt
@@ -26,7 +26,7 @@ data class HotList(
     @JacksonXmlProperty(isAttribute = true) val termsOfUse: String,
 
     /** List of the actual things. */
-    @JacksonXmlProperty(localName = "item") val results: List<HotListItem>
+    @JacksonXmlProperty(localName = "item") val results: List<HotListItem>,
 )
 
 /** Encapsulates a ranked item in the hot list. */

--- a/src/main/kotlin/org/audux/bgg/response/KSerializers.kt
+++ b/src/main/kotlin/org/audux/bgg/response/KSerializers.kt
@@ -59,7 +59,7 @@ internal class PollSerializer : KSerializer<Poll> {
             arrayOf(
                 LanguageDependencePoll::class,
                 PlayerAgePoll::class,
-                NumberOfPlayersPoll::class
+                NumberOfPlayersPoll::class,
             ),
             arrayOf(
                 LanguageDependencePoll.serializer(),

--- a/src/main/kotlin/org/audux/bgg/response/Plays.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Plays.kt
@@ -41,7 +41,7 @@ data class Plays(
     @JacksonXmlProperty(isAttribute = true) val page: Int,
 
     /** List of the actual plays. */
-    @JacksonXmlProperty(localName = "play") val plays: List<Play> = listOf()
+    @JacksonXmlProperty(localName = "play") val plays: List<Play> = listOf(),
 )
 
 /**

--- a/src/main/kotlin/org/audux/bgg/response/Response.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Response.kt
@@ -28,10 +28,7 @@ import kotlinx.coroutines.withContext
  * @property error Contains the response body when the response could not be parsed by [T]
  * @property data Contains the wrapped successful response
  */
-data class Response<T>(
-    val error: String? = null,
-    val data: T? = null,
-) {
+data class Response<T>(val error: String? = null, val data: T? = null) {
     /** Whether the request was successful or not. */
     fun isSuccess() = error.isNullOrBlank()
 

--- a/src/main/kotlin/org/audux/bgg/response/Search.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Search.kt
@@ -31,7 +31,7 @@ data class SearchResults(
     @JacksonXmlProperty(isAttribute = true) val total: Int,
 
     /** List of the actual things. */
-    @JacksonXmlProperty(localName = "item") val results: List<SearchResult>
+    @JacksonXmlProperty(localName = "item") val results: List<SearchResult>,
 )
 
 /** Encapsulates a single search result. */

--- a/src/main/kotlin/org/audux/bgg/response/SitemapIndex.kt
+++ b/src/main/kotlin/org/audux/bgg/response/SitemapIndex.kt
@@ -39,7 +39,7 @@ data class SitemapLocation(
     /** The URL/Web address of the sitemap. */
     @JsonProperty("loc")
     @JsonDeserialize(using = TrimmedStringDeserializer::class)
-    val location: String,
+    val location: String
 ) {
     /**
      * Calculated property that represents the type of sitemap e.g. Board games, Video games, Board

--- a/src/main/kotlin/org/audux/bgg/response/Things.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Things.kt
@@ -40,7 +40,7 @@ data class Things(
     @JacksonXmlProperty(isAttribute = true) val termsOfUse: String,
 
     /** List of the actual things. */
-    @JacksonXmlProperty(localName = "item") val things: List<Thing>
+    @JacksonXmlProperty(localName = "item") val things: List<Thing>,
 )
 
 /**
@@ -280,7 +280,7 @@ data class Video(
     @JacksonXmlProperty(isAttribute = true)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssz")
     @Serializable(with = LocalDateTimeSerializer::class)
-    val postDate: LocalDateTime
+    val postDate: LocalDateTime,
 )
 
 // region Comments
@@ -332,6 +332,7 @@ data class Comment(
     /** The comment the user posted. */
     @JacksonXmlProperty(isAttribute = true) val value: String?,
 )
+
 // endregion
 
 // region Marketplace
@@ -375,6 +376,7 @@ data class Weblink(
     /** The title of the resource. */
     val title: String,
 )
+
 // endregion
 
 // region All Poll classes
@@ -385,7 +387,7 @@ data class Weblink(
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "name"
+    property = "name",
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = LanguageDependencePoll::class, name = "language_dependence"),

--- a/src/main/kotlin/org/audux/bgg/response/Thread.kt
+++ b/src/main/kotlin/org/audux/bgg/response/Thread.kt
@@ -56,7 +56,7 @@ data class Article(
     /** Username of the article creator/poster. */
     @JsonDeserialize(using = TrimmedStringDeserializer::class)
     @JacksonXmlProperty(isAttribute = true)
-    val username: String,
+    val username: String?,
 
     /** The number of edits made to this article. */
     @JacksonXmlProperty(isAttribute = true) val numEdits: Int,

--- a/src/main/kotlin/org/audux/bgg/response/User.kt
+++ b/src/main/kotlin/org/audux/bgg/response/User.kt
@@ -113,7 +113,7 @@ data class Buddy(
     @JacksonXmlProperty(isAttribute = true) val id: Int,
 
     /** The username of the buddy. */
-    @JacksonXmlProperty(isAttribute = true) val name: String
+    @JacksonXmlProperty(isAttribute = true) val name: String,
 )
 
 /** Guilds user is a member of. */

--- a/src/test/kotlin/org/audux/bgg/BggClientTest.kt
+++ b/src/test/kotlin/org/audux/bgg/BggClientTest.kt
@@ -98,7 +98,7 @@ class BggClientTest {
                     message =
                         "Got status code 202 Retrying request[https://boardgamegeek.com/xmlapi2/user?name=Novaeux",
                     tag = "HttpRequestRetry",
-                    throwable = null
+                    throwable = null,
                 )
             )
     }
@@ -115,7 +115,7 @@ class BggClientTest {
             request {
                     Response(
                         data = client().get("https://www.google.com/test").bodyAsText(),
-                        error = null
+                        error = null,
                     )
                 }
                 .callAsync() {
@@ -142,7 +142,7 @@ class BggClientTest {
                 request {
                         Response(
                             data = client().get("https://www.google.com/test").bodyAsText(),
-                            error = null
+                            error = null,
                         )
                     }
                     .callAsync()
@@ -166,7 +166,7 @@ class BggClientTest {
                     request {
                             Response(
                                 data = client().get("https://www.google.com/test").bodyAsText(),
-                                error = null
+                                error = null,
                             )
                         }
                         .call()
@@ -190,7 +190,7 @@ class BggClientTest {
                     request {
                             Response(
                                 data = client().get("https://www.google.com/test").bodyAsText(),
-                                error = null
+                                error = null,
                             )
                         }
                         .call()

--- a/src/test/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPluginTest.kt
+++ b/src/test/kotlin/org/audux/bgg/plugin/ClientConcurrentRateLimitPluginTest.kt
@@ -24,17 +24,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.audux.bgg.util.TestUtils.delayedResponse
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /** Tests for [ClientConcurrentRateLimitPlugin] and [ConcurrentRequestLimiter]. */
 class ClientConcurrentRateLimitPluginTest {
     private lateinit var requestLimiter: ConcurrentRequestLimiter
-
-    @BeforeEach
-    fun beforeEach() {
-        AtomicSingletonInteger.instance.reset()
-    }
 
     @Test
     fun `Does not enqueue incoming requests that do not exceed the concurrent requests limit`() {

--- a/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
+++ b/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
@@ -19,153 +19,161 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockEngineConfig
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.get
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.audux.bgg.util.TestUtils.instantResponse
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Tests for [ClientConcurrentRateLimitPlugin] and [ConcurrentRequestLimiter]. */
 class ClientRateLimitPluginTest {
-    private lateinit var requestLimiter: RequestLimiter
+  private lateinit var requestLimiter: RequestLimiter
 
-    @BeforeEach
-    fun beforeEach() {
-        AtomicSingletonInteger.instance.reset()
+  @BeforeEach
+  fun beforeEach() {
+    AtomicSingletonInteger.instance.reset()
+  }
+
+  @Test
+  fun `Enqueue incoming requests that do not exceed the request limit for the current window`() {
+    val client = createClient(requestLimit = 10) { repeat(4) { addHandler(instantResponse()) } }
+
+    val jobs = runBlocking {
+      // Launch 4 requests.
+      val jobs = (0..3).map { launch { client.get("/") } }
+
+      delay(2)
+
+      // Ensure 2 requests are in-flight and 2 are queued.
+      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(4)
+
+      jobs
     }
 
-    @Test
-    fun `Enqueue incoming requests that do not exceed the request limit for the current window`() {
-        val client = createClient(requestLimit = 10) { repeat(4) { addHandler(instantResponse()) } }
+    // After all coroutines have finished ensure 3 requests are made
+    val engine = client.engine as MockEngine
+    assertThat(engine.requestHistory).hasSize(4)
+    assertAllJobsAre(jobs) { !isActive }
+    assertAllJobsAre(jobs) { !isCancelled }
+    assertAllJobsAre(jobs) { isCompleted }
+  }
 
-        val jobs = runBlocking {
-            // Launch 4 requests.
-            val jobs = (0..3).map { launch { client.get("/") } }
+  @Test
+  fun `Does not enqueue incoming requests that exceed the request limit for the current window`() {
+    val client = createClient(requestLimit = 2) { repeat(4) { addHandler(instantResponse()) } }
 
-            delay(2)
+    val jobs = runBlocking {
+      // Launch 4 requests.
+      val jobs = (0..3).map { launch { client.get("/") } }
 
-            // Ensure 2 requests are in-flight and 2 are queued.
-            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(4)
+      delay(2)
 
-            jobs
+      // Ensure 2 requests are in-flight and 2 are queued.
+      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+      jobs
+    }
+
+    // After all coroutines have finished ensure 3 requests are made
+    val engine = client.engine as MockEngine
+    assertThat(engine.requestHistory).hasSize(4)
+    assertAllJobsAre(jobs) { !isActive }
+    assertAllJobsAre(jobs) { !isCancelled }
+    assertAllJobsAre(jobs) { isCompleted }
+  }
+
+  @RepeatedTest(100)
+  fun `delays requests to the new window`() {
+    val client = createClient(requestLimit = 2) { repeat(5) { addHandler(instantResponse()) } }
+
+    runBlocking {
+      val job1 = launch { client.get("/1") }
+      val job2 = launch { client.get("/2") }
+      delay(2) // ensure jobs are running
+
+      val job3 = launch { client.get("/3") }
+      val job4 = launch { client.get("/4") }
+      val job5 = launch { client.get("/5") }
+      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+      delay(10) // ensure jobs 1 and 2 are completed
+
+      assertThat(job1.isCompleted).isTrue()
+      assertThat(job2.isCompleted).isTrue()
+      assertThat(job3.isActive).isTrue()
+      assertThat(job4.isActive).isTrue()
+      assertThat(job5.isActive).isTrue()
+
+      delay(20) // ensure jobs 3 and 4 are completed
+
+      assertThat(job1.isCompleted).isTrue()
+      assertThat(job2.isCompleted).isTrue()
+      assertThat(job3.isCompleted).isTrue()
+      assertThat(job4.isCompleted).isTrue()
+      assertThat(job5.isActive).isTrue()
+
+      delay(30) // ensure job 5 is completed.
+
+      assertThat(job5.isCompleted).isTrue()
+    }
+
+    val engine = client.engine as MockEngine
+    assertThat(engine.requestHistory).hasSize(5)
+  }
+
+  @Test
+  fun `Enqueues incoming requests that would exceed the requests limit even for different clients`() {
+    val clients =
+      listOf(
+        createClient(requestLimit = 2) { addHandler(instantResponse()) },
+        createClient(requestLimit = 2) { addHandler(instantResponse()) },
+        createClient(requestLimit = 2) { addHandler(instantResponse()) },
+        createClient(requestLimit = 2) { addHandler(instantResponse()) },
+        createClient(requestLimit = 2) { addHandler(instantResponse()) },
+      )
+
+    val jobs = runBlocking {
+      // Launch 5 concurrent requests
+      val jobs = clients.map { client -> launch { client.get("/") } }
+
+      // Minor delay to ensure client.get calls are done
+      delay(2)
+
+      // Ensure 2 requests are in-flight and 3 are queued.
+      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+      jobs
+    }
+
+    // After all coroutines have finished ensure 3 requests are made
+    val totalRequests = clients.map { it.engine as MockEngine }.sumOf { it.requestHistory.size }
+    assertThat(totalRequests).isEqualTo(5)
+    assertAllJobsAre(jobs) { !isActive }
+    assertAllJobsAre(jobs) { !isCancelled }
+    assertAllJobsAre(jobs) { isCompleted }
+  }
+
+  private fun createClient(
+    requestLimit: Int,
+    windowSize: Duration = 20.milliseconds,
+    responses: MockEngineConfig.() -> Unit,
+  ): HttpClient {
+    return HttpClient(MockEngine(MockEngineConfig().apply { responses(this) })) {
+      install(
+        createClientPlugin("ClientRateLimitPlugin") {
+          requestLimiter = RequestLimiter(requestLimit, windowSize)
+          onRequest { request, _ -> requestLimiter.onNewRequest(request) }
         }
-
-        // After all coroutines have finished ensure 3 requests are made
-        val engine = client.engine as MockEngine
-        assertThat(engine.requestHistory).hasSize(4)
-        assertAllJobsAre(jobs) { !isActive }
-        assertAllJobsAre(jobs) { !isCancelled }
-        assertAllJobsAre(jobs) { isCompleted }
+      )
     }
+  }
 
-    @Test
-    fun `Does not enqueue incoming requests that exceed the request limit for the current window`() {
-        val client = createClient(requestLimit = 2) { repeat(4) { addHandler(instantResponse()) } }
-
-        val jobs = runBlocking {
-            // Launch 4 requests.
-            val jobs = (0..3).map { launch { client.get("/") } }
-
-            delay(2)
-
-            // Ensure 2 requests are in-flight and 2 are queued.
-            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-            jobs
-        }
-
-        // After all coroutines have finished ensure 3 requests are made
-        val engine = client.engine as MockEngine
-        assertThat(engine.requestHistory).hasSize(4)
-        assertAllJobsAre(jobs) { !isActive }
-        assertAllJobsAre(jobs) { !isCancelled }
-        assertAllJobsAre(jobs) { isCompleted }
-    }
-
-    @Test
-    fun `delays requests to the new window`() {
-        val client = createClient(requestLimit = 2) { repeat(4) { addHandler(instantResponse()) } }
-
-        runBlocking {
-            val job1 = launch { client.get("/") }
-            val job2 = launch { client.get("/") }
-            delay(2) // ensure jobs are running
-
-            val job3 = launch { client.get("/") }
-            val job4 = launch { client.get("/") }
-            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-            delay(10) // ensure jobs 1 and 2 are completed
-
-            assertThat(job1.isCompleted).isTrue()
-            assertThat(job2.isCompleted).isTrue()
-            assertThat(job3.isActive).isTrue()
-            assertThat(job4.isActive).isTrue()
-
-            delay(30) // ensure jobs 3 and 4 are completed
-
-            assertThat(job1.isCompleted).isTrue()
-            assertThat(job2.isCompleted).isTrue()
-            assertThat(job3.isCompleted).isTrue()
-            assertThat(job4.isCompleted).isTrue()
-        }
-
-        val engine = client.engine as MockEngine
-        assertThat(engine.requestHistory).hasSize(4)
-    }
-
-    @Test
-    fun `Enqueues incoming requests that would exceed the requests limit even for different clients`() {
-        val clients =
-            listOf(
-                createClient(requestLimit = 2) { addHandler(instantResponse()) },
-                createClient(requestLimit = 2) { addHandler(instantResponse()) },
-                createClient(requestLimit = 2) { addHandler(instantResponse()) },
-                createClient(requestLimit = 2) { addHandler(instantResponse()) },
-                createClient(requestLimit = 2) { addHandler(instantResponse()) },
-            )
-
-        val jobs = runBlocking {
-            // Launch 5 concurrent requests
-            val jobs = clients.map { client -> launch { client.get("/") } }
-
-            // Minor delay to ensure client.get calls are done
-            delay(2)
-
-            // Ensure 2 requests are in-flight and 3 are queued.
-            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-            jobs
-        }
-
-        // After all coroutines have finished ensure 3 requests are made
-        val totalRequests = clients.map { it.engine as MockEngine }.sumOf { it.requestHistory.size }
-        assertThat(totalRequests).isEqualTo(5)
-        assertAllJobsAre(jobs) { !isActive }
-        assertAllJobsAre(jobs) { !isCancelled }
-        assertAllJobsAre(jobs) { isCompleted }
-    }
-
-    private fun createClient(
-        requestLimit: Int,
-        windowSize: Duration = 20.milliseconds,
-        responses: MockEngineConfig.() -> Unit,
-    ): HttpClient {
-        return HttpClient(MockEngine(MockEngineConfig().apply { responses(this) })) {
-            install(
-                createClientPlugin("ClientRateLimitPlugin") {
-                    requestLimiter = RequestLimiter(requestLimit, windowSize)
-                    onRequest { request, _ -> requestLimiter.onNewRequest(request) }
-                }
-            )
-        }
-    }
-
-    private fun assertAllJobsAre(jobs: List<Job>, predicate: Job.() -> Boolean) {
-        assertThat(jobs.all(predicate)).isTrue()
-    }
+  private fun assertAllJobsAre(jobs: List<Job>, predicate: Job.() -> Boolean) {
+    assertThat(jobs.all(predicate)).isTrue()
+  }
 }

--- a/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
+++ b/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
@@ -19,6 +19,8 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockEngineConfig
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.get
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -27,153 +29,151 @@ import org.audux.bgg.util.TestUtils.instantResponse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 /** Tests for [ClientConcurrentRateLimitPlugin] and [ConcurrentRequestLimiter]. */
 class ClientRateLimitPluginTest {
-  private lateinit var requestLimiter: RequestLimiter
+    private lateinit var requestLimiter: RequestLimiter
 
-  @BeforeEach
-  fun beforeEach() {
-    AtomicSingletonInteger.instance.reset()
-  }
-
-  @Test
-  fun `Enqueue incoming requests that do not exceed the request limit for the current window`() {
-    val client = createClient(requestLimit = 10) { repeat(4) { addHandler(instantResponse()) } }
-
-    val jobs = runBlocking {
-      // Launch 4 requests.
-      val jobs = (0..3).map { launch { client.get("/") } }
-
-      delay(2)
-
-      // Ensure 2 requests are in-flight and 2 are queued.
-      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(4)
-
-      jobs
+    @BeforeEach
+    fun beforeEach() {
+        AtomicSingletonInteger.instance.reset()
     }
 
-    // After all coroutines have finished ensure 3 requests are made
-    val engine = client.engine as MockEngine
-    assertThat(engine.requestHistory).hasSize(4)
-    assertAllJobsAre(jobs) { !isActive }
-    assertAllJobsAre(jobs) { !isCancelled }
-    assertAllJobsAre(jobs) { isCompleted }
-  }
+    @Test
+    fun `Enqueue incoming requests that do not exceed the request limit for the current window`() {
+        val client = createClient(requestLimit = 10) { repeat(4) { addHandler(instantResponse()) } }
 
-  @Test
-  fun `Does not enqueue incoming requests that exceed the request limit for the current window`() {
-    val client = createClient(requestLimit = 2) { repeat(4) { addHandler(instantResponse()) } }
+        val jobs = runBlocking {
+            // Launch 4 requests.
+            val jobs = (0..3).map { launch { client.get("/") } }
 
-    val jobs = runBlocking {
-      // Launch 4 requests.
-      val jobs = (0..3).map { launch { client.get("/") } }
+            delay(2)
 
-      delay(2)
+            // Ensure 2 requests are in-flight and 2 are queued.
+            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(4)
 
-      // Ensure 2 requests are in-flight and 2 are queued.
-      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-      jobs
-    }
-
-    // After all coroutines have finished ensure 3 requests are made
-    val engine = client.engine as MockEngine
-    assertThat(engine.requestHistory).hasSize(4)
-    assertAllJobsAre(jobs) { !isActive }
-    assertAllJobsAre(jobs) { !isCancelled }
-    assertAllJobsAre(jobs) { isCompleted }
-  }
-
-  @RepeatedTest(100)
-  fun `delays requests to the new window`() {
-    val client = createClient(requestLimit = 2) { repeat(5) { addHandler(instantResponse()) } }
-
-    runBlocking {
-      val job1 = launch { client.get("/1") }
-      val job2 = launch { client.get("/2") }
-      delay(2) // ensure jobs are running
-
-      val job3 = launch { client.get("/3") }
-      val job4 = launch { client.get("/4") }
-      val job5 = launch { client.get("/5") }
-      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-      delay(10) // ensure jobs 1 and 2 are completed
-
-      assertThat(job1.isCompleted).isTrue()
-      assertThat(job2.isCompleted).isTrue()
-      assertThat(job3.isActive).isTrue()
-      assertThat(job4.isActive).isTrue()
-      assertThat(job5.isActive).isTrue()
-
-      delay(20) // ensure jobs 3 and 4 are completed
-
-      assertThat(job1.isCompleted).isTrue()
-      assertThat(job2.isCompleted).isTrue()
-      assertThat(job3.isCompleted).isTrue()
-      assertThat(job4.isCompleted).isTrue()
-      assertThat(job5.isActive).isTrue()
-
-      delay(30) // ensure job 5 is completed.
-
-      assertThat(job5.isCompleted).isTrue()
-    }
-
-    val engine = client.engine as MockEngine
-    assertThat(engine.requestHistory).hasSize(5)
-  }
-
-  @Test
-  fun `Enqueues incoming requests that would exceed the requests limit even for different clients`() {
-    val clients =
-      listOf(
-        createClient(requestLimit = 2) { addHandler(instantResponse()) },
-        createClient(requestLimit = 2) { addHandler(instantResponse()) },
-        createClient(requestLimit = 2) { addHandler(instantResponse()) },
-        createClient(requestLimit = 2) { addHandler(instantResponse()) },
-        createClient(requestLimit = 2) { addHandler(instantResponse()) },
-      )
-
-    val jobs = runBlocking {
-      // Launch 5 concurrent requests
-      val jobs = clients.map { client -> launch { client.get("/") } }
-
-      // Minor delay to ensure client.get calls are done
-      delay(2)
-
-      // Ensure 2 requests are in-flight and 3 are queued.
-      assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
-
-      jobs
-    }
-
-    // After all coroutines have finished ensure 3 requests are made
-    val totalRequests = clients.map { it.engine as MockEngine }.sumOf { it.requestHistory.size }
-    assertThat(totalRequests).isEqualTo(5)
-    assertAllJobsAre(jobs) { !isActive }
-    assertAllJobsAre(jobs) { !isCancelled }
-    assertAllJobsAre(jobs) { isCompleted }
-  }
-
-  private fun createClient(
-    requestLimit: Int,
-    windowSize: Duration = 20.milliseconds,
-    responses: MockEngineConfig.() -> Unit,
-  ): HttpClient {
-    return HttpClient(MockEngine(MockEngineConfig().apply { responses(this) })) {
-      install(
-        createClientPlugin("ClientRateLimitPlugin") {
-          requestLimiter = RequestLimiter(requestLimit, windowSize)
-          onRequest { request, _ -> requestLimiter.onNewRequest(request) }
+            jobs
         }
-      )
-    }
-  }
 
-  private fun assertAllJobsAre(jobs: List<Job>, predicate: Job.() -> Boolean) {
-    assertThat(jobs.all(predicate)).isTrue()
-  }
+        // After all coroutines have finished ensure 3 requests are made
+        val engine = client.engine as MockEngine
+        assertThat(engine.requestHistory).hasSize(4)
+        assertAllJobsAre(jobs) { !isActive }
+        assertAllJobsAre(jobs) { !isCancelled }
+        assertAllJobsAre(jobs) { isCompleted }
+    }
+
+    @Test
+    fun `Does not enqueue incoming requests that exceed the request limit for the current window`() {
+        val client = createClient(requestLimit = 2) { repeat(4) { addHandler(instantResponse()) } }
+
+        val jobs = runBlocking {
+            // Launch 4 requests.
+            val jobs = (0..3).map { launch { client.get("/") } }
+
+            delay(2)
+
+            // Ensure 2 requests are in-flight and 2 are queued.
+            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+            jobs
+        }
+
+        // After all coroutines have finished ensure 3 requests are made
+        val engine = client.engine as MockEngine
+        assertThat(engine.requestHistory).hasSize(4)
+        assertAllJobsAre(jobs) { !isActive }
+        assertAllJobsAre(jobs) { !isCancelled }
+        assertAllJobsAre(jobs) { isCompleted }
+    }
+
+    @RepeatedTest(100)
+    fun `delays requests to the new window`() {
+        val client = createClient(requestLimit = 2) { repeat(5) { addHandler(instantResponse()) } }
+
+        runBlocking {
+            val job1 = launch { client.get("/1") }
+            val job2 = launch { client.get("/2") }
+            delay(2) // ensure jobs are running
+
+            val job3 = launch { client.get("/3") }
+            val job4 = launch { client.get("/4") }
+            val job5 = launch { client.get("/5") }
+            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+            delay(10) // ensure jobs 1 and 2 are completed
+
+            assertThat(job1.isCompleted).isTrue()
+            assertThat(job2.isCompleted).isTrue()
+            assertThat(job3.isActive).isTrue()
+            assertThat(job4.isActive).isTrue()
+            assertThat(job5.isActive).isTrue()
+
+            delay(20) // ensure jobs 3 and 4 are completed
+
+            assertThat(job1.isCompleted).isTrue()
+            assertThat(job2.isCompleted).isTrue()
+            assertThat(job3.isCompleted).isTrue()
+            assertThat(job4.isCompleted).isTrue()
+            assertThat(job5.isActive).isTrue()
+
+            delay(30) // ensure job 5 is completed.
+
+            assertThat(job5.isCompleted).isTrue()
+        }
+
+        val engine = client.engine as MockEngine
+        assertThat(engine.requestHistory).hasSize(5)
+    }
+
+    @Test
+    fun `Enqueues incoming requests that would exceed the requests limit even for different clients`() {
+        val clients =
+            listOf(
+                createClient(requestLimit = 2) { addHandler(instantResponse()) },
+                createClient(requestLimit = 2) { addHandler(instantResponse()) },
+                createClient(requestLimit = 2) { addHandler(instantResponse()) },
+                createClient(requestLimit = 2) { addHandler(instantResponse()) },
+                createClient(requestLimit = 2) { addHandler(instantResponse()) },
+            )
+
+        val jobs = runBlocking {
+            // Launch 5 concurrent requests
+            val jobs = clients.map { client -> launch { client.get("/") } }
+
+            // Minor delay to ensure client.get calls are done
+            delay(2)
+
+            // Ensure 2 requests are in-flight and 3 are queued.
+            assertThat(requestLimiter.requestsInCurrentWindow.get()).isEqualTo(2)
+
+            jobs
+        }
+
+        // After all coroutines have finished ensure 3 requests are made
+        val totalRequests = clients.map { it.engine as MockEngine }.sumOf { it.requestHistory.size }
+        assertThat(totalRequests).isEqualTo(5)
+        assertAllJobsAre(jobs) { !isActive }
+        assertAllJobsAre(jobs) { !isCancelled }
+        assertAllJobsAre(jobs) { isCompleted }
+    }
+
+    private fun createClient(
+        requestLimit: Int,
+        windowSize: Duration = 20.milliseconds,
+        responses: MockEngineConfig.() -> Unit,
+    ): HttpClient {
+        return HttpClient(MockEngine(MockEngineConfig().apply { responses(this) })) {
+            install(
+                createClientPlugin("ClientRateLimitPlugin") {
+                    requestLimiter = RequestLimiter(requestLimit, windowSize)
+                    onRequest { request, _ -> requestLimiter.onNewRequest(request) }
+                }
+            )
+        }
+    }
+
+    private fun assertAllJobsAre(jobs: List<Job>, predicate: Job.() -> Boolean) {
+        assertThat(jobs.all(predicate)).isTrue()
+    }
 }

--- a/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
+++ b/src/test/kotlin/org/audux/bgg/plugin/ClientRateLimitPluginTest.kt
@@ -26,18 +26,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.audux.bgg.util.TestUtils.instantResponse
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 
 /** Tests for [ClientConcurrentRateLimitPlugin] and [ConcurrentRequestLimiter]. */
 class ClientRateLimitPluginTest {
     private lateinit var requestLimiter: RequestLimiter
-
-    @BeforeEach
-    fun beforeEach() {
-        AtomicSingletonInteger.instance.reset()
-    }
 
     @Test
     fun `Enqueue incoming requests that do not exceed the request limit for the current window`() {

--- a/src/test/kotlin/org/audux/bgg/request/CollectionRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/CollectionRequestTest.kt
@@ -164,7 +164,7 @@ class CollectionRequestTest {
                                 append("maxplays", "99")
                                 append("collid", "-1")
                                 append("modifiedsince", "2020-01-01 00:00:00")
-                            }
+                            },
                     )
                     .build()
             assertThat(request.url).isEqualTo(expectedUrl)

--- a/src/test/kotlin/org/audux/bgg/request/FamilyRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/FamilyRequestTest.kt
@@ -54,7 +54,7 @@ class FamilyRequestTest {
             val response =
                 BggClient.familyItems(
                         ids = arrayOf(50152, 50153),
-                        arrayOf(FamilyType.BOARD_GAME_FAMILY, FamilyType.RPG)
+                        arrayOf(FamilyType.BOARD_GAME_FAMILY, FamilyType.RPG),
                     )
                     .call()
 

--- a/src/test/kotlin/org/audux/bgg/request/ForumListRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/ForumListRequestTest.kt
@@ -30,12 +30,7 @@ class ForumListRequestTest {
             val engine = TestUtils.setupMockEngine("forumlist")
             BggClient.engine = { engine }
 
-            val response =
-                BggClient.forumList(
-                        id = 342942,
-                        type = ForumListType.THING,
-                    )
-                    .call()
+            val response = BggClient.forumList(id = 342942, type = ForumListType.THING).call()
 
             val request = engine.requestHistory[0]
             assertThat(engine.requestHistory).hasSize(1)

--- a/src/test/kotlin/org/audux/bgg/request/ForumRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/ForumRequestTest.kt
@@ -80,7 +80,7 @@ class ForumRequestTest {
                 TestUtils.setupMockEngine(
                     "forum?id=3696796",
                     "forum?id=3696796&page=2",
-                    "forum?id=3696796&page=3"
+                    "forum?id=3696796&page=3",
                 )
 
             BggClient.engine = { engine }
@@ -104,7 +104,7 @@ class ForumRequestTest {
                 TestUtils.setupMockEngine(
                     "forum?id=3696796",
                     "forum?id=3696796&page=2",
-                    "forum?id=3696796&page=3"
+                    "forum?id=3696796&page=3",
                 )
             BggClient.engine = { engine }
 
@@ -114,7 +114,7 @@ class ForumRequestTest {
             assertThat(engine.requestHistory.map { it.url })
                 .containsExactly(
                     Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796"),
-                    Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796&page=2")
+                    Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796&page=2"),
                 )
             assertThat(response.data!!.numThreads).isEqualTo(148)
             assertThat(response.data!!.threads).hasSize(100)
@@ -132,7 +132,7 @@ class ForumRequestTest {
             assertThat(engine.requestHistory.map { it.url })
                 .containsExactly(
                     Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796&page=2"),
-                    Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796&page=3")
+                    Url("https://boardgamegeek.com/xmlapi2/forum?id=3696796&page=3"),
                 )
             assertThat(response.data!!.numThreads).isEqualTo(148)
             assertThat(response.data!!.threads).hasSize(98)
@@ -144,7 +144,7 @@ class ForumRequestTest {
                 TestUtils.setupMockEngine(
                     "forum?id=3696796",
                     "forum?id=-1", // Erroneous reply
-                    "forum?id=3696796&page=3"
+                    "forum?id=3696796&page=3",
                 )
 
             BggClient.engine = { engine }

--- a/src/test/kotlin/org/audux/bgg/request/GuildsRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/GuildsRequestTest.kt
@@ -74,13 +74,7 @@ class GuildsRequestTest {
         BggClient.engine = { engine }
 
         val response =
-            BggClient.guild(
-                    id = 2310,
-                    members = Inclusion.INCLUDE,
-                    sort = "date",
-                    page = 1,
-                )
-                .call()
+            BggClient.guild(id = 2310, members = Inclusion.INCLUDE, sort = "date", page = 1).call()
 
         val request = engine.requestHistory[0]
         assertThat(request.url)
@@ -145,7 +139,7 @@ class GuildsRequestTest {
             val engine =
                 TestUtils.setupMockEngine(
                     "guilds?id=2310&members=1&page=2",
-                    "guilds?id=2310&members=1&page=3"
+                    "guilds?id=2310&members=1&page=3",
                 )
             BggClient.engine = { engine }
 

--- a/src/test/kotlin/org/audux/bgg/request/HotListRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/HotListRequestTest.kt
@@ -74,7 +74,7 @@ class HotListRequestTest {
                         Headers.build {
                             append("content-encoding", "gzip")
                             append("content-type", "text/xml; charset=\"UTF-8\"")
-                        }
+                        },
                 )
             BggClient.engine = { engine }
 

--- a/src/test/kotlin/org/audux/bgg/request/SearchRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/SearchRequestTest.kt
@@ -37,9 +37,7 @@ class SearchRequestTest {
             assertThat(request.method).isEqualTo(HttpMethod.Get)
             assertThat(request.headers).isEqualTo(TestUtils.DEFAULT_HEADERS)
             assertThat(request.url)
-                .isEqualTo(
-                    Url("https://boardgamegeek.com/xmlapi2/search?query=my+little"),
-                )
+                .isEqualTo(Url("https://boardgamegeek.com/xmlapi2/search?query=my+little"))
             assertThat(response.isError()).isFalse()
             assertThat(response.isSuccess()).isTrue()
             assertThat(response.data?.results).hasSize(144)
@@ -56,7 +54,7 @@ class SearchRequestTest {
                 BggClient.search(
                         query = "my little",
                         types = arrayOf(ThingType.BOARD_GAME, ThingType.RPG_ITEM),
-                        exactMatch = true
+                        exactMatch = true,
                     )
                     .call()
 
@@ -65,7 +63,7 @@ class SearchRequestTest {
                 .isEqualTo(
                     Url(
                         "https://boardgamegeek.com/xmlapi2/search?query=my+little&type=boardgame%2Crpgitem&exact=1"
-                    ),
+                    )
                 )
             assertThat(response.data?.results).hasSize(144)
         }

--- a/src/test/kotlin/org/audux/bgg/request/ThingsRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/ThingsRequestTest.kt
@@ -48,7 +48,7 @@ class ThingsRequestTest {
                             protocol = URLProtocol.HTTPS,
                             host = "boardgamegeek.com",
                             pathSegments = listOf("xmlapi2", "thing"),
-                            parameters = Parameters.build { append("id", "1,2,3") }
+                            parameters = Parameters.build { append("id", "1,2,3") },
                         )
                         .build()
                 )
@@ -97,7 +97,7 @@ class ThingsRequestTest {
                                     append("comments", "1")
                                     append("page", "2")
                                     append("pagesize", "100")
-                                }
+                                },
                         )
                         .build()
                 )

--- a/src/test/kotlin/org/audux/bgg/request/ThreadRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/ThreadRequestTest.kt
@@ -79,7 +79,7 @@ class ThreadRequestTest {
                         id = 3208373,
                         minArticleId = 10,
                         minArticleDate = LocalDateTime.of(2020, 1, 1, 0, 0),
-                        count = 100_000
+                        count = 100_000,
                     )
                     .call()
 

--- a/src/test/kotlin/org/audux/bgg/request/UserRequestTest.kt
+++ b/src/test/kotlin/org/audux/bgg/request/UserRequestTest.kt
@@ -99,7 +99,7 @@ class UserRequestTest {
                 BggClient.user(
                         name = "Novaeux",
                         buddies = Inclusion.INCLUDE,
-                        guilds = Inclusion.INCLUDE
+                        guilds = Inclusion.INCLUDE,
                     )
                     .paginate()
                     .call()
@@ -183,7 +183,7 @@ class UserRequestTest {
                 BggClient.user(
                         name = "Novaeux",
                         buddies = Inclusion.INCLUDE,
-                        guilds = Inclusion.INCLUDE
+                        guilds = Inclusion.INCLUDE,
                     )
                     .paginate(toPage = 2)
                     .call()
@@ -216,7 +216,7 @@ class UserRequestTest {
                         name = "Novaeux",
                         buddies = Inclusion.INCLUDE,
                         guilds = Inclusion.INCLUDE,
-                        page = 2
+                        page = 2,
                     )
                     .paginate()
                     .call()
@@ -252,7 +252,7 @@ class UserRequestTest {
                 BggClient.user(
                         name = "Novaeux",
                         buddies = Inclusion.INCLUDE,
-                        guilds = Inclusion.INCLUDE
+                        guilds = Inclusion.INCLUDE,
                     )
                     .paginate()
                     .call()
@@ -289,7 +289,7 @@ class UserRequestTest {
                 BggClient.user(
                         name = "Novaeux",
                         buddies = Inclusion.INCLUDE,
-                        guilds = Inclusion.INCLUDE
+                        guilds = Inclusion.INCLUDE,
                     )
                     .paginate()
                     .call()

--- a/src/test/kotlin/org/audux/bgg/response/CollectionResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/CollectionResponseTest.kt
@@ -44,7 +44,7 @@ class CollectionResponseTest {
                 TestUtils.xml(
                     "collection?username=novaeux&stats=1&subtype=boardgame&excludesubtype=boardgameexpansion"
                 ),
-                Collection::class.java
+                Collection::class.java,
             )
         val encodedCollection = Json.encodeToString(collection)
 
@@ -58,7 +58,7 @@ class CollectionResponseTest {
                 TestUtils.xml(
                     "collection?username=novaeux&stats=1&subtype=boardgame&excludesubtype=boardgameexpansion"
                 ),
-                Collection::class.java
+                Collection::class.java,
             )
 
         assertThat(results.items).hasSize(105)
@@ -104,7 +104,7 @@ class CollectionResponseTest {
                                                 friendlyName = "Board Game Rank",
                                                 type = "subtype",
                                                 value = "89",
-                                                bayesAverage = "7.58314"
+                                                bayesAverage = "7.58314",
                                             ),
                                             Rank(
                                                 id = 5497,
@@ -112,7 +112,7 @@ class CollectionResponseTest {
                                                 friendlyName = "Strategy Game Rank",
                                                 type = "family",
                                                 value = "90",
-                                                bayesAverage = "7.5477"
+                                                bayesAverage = "7.5477",
                                             ),
                                             Rank(
                                                 id = 5499,
@@ -120,11 +120,11 @@ class CollectionResponseTest {
                                                 friendlyName = "Family Game Rank",
                                                 type = "family",
                                                 value = "12",
-                                                bayesAverage = "7.57952"
+                                                bayesAverage = "7.57952",
                                             ),
                                         ),
                                 ),
-                        )
+                        ),
                 )
             )
     }
@@ -134,7 +134,7 @@ class CollectionResponseTest {
         val results =
             mapper.readValue(
                 TestUtils.xml("collection?username=novaeux&stats=1&subtype=rpgitem"),
-                Collection::class.java
+                Collection::class.java,
             )
 
         assertThat(results.items).hasSize(1)

--- a/src/test/kotlin/org/audux/bgg/response/FamilyResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/FamilyResponseTest.kt
@@ -62,21 +62,21 @@ class FamilyResponseTest {
                                 type = "boardgamefamily",
                                 id = 65901,
                                 value = "Age of Industry",
-                                inbound = true
+                                inbound = true,
                             ),
                             Link(
                                 type = "boardgamefamily",
                                 id = 99424,
                                 value = "Age of Industry Expansion #1: Japan and Minnesota",
-                                inbound = true
+                                inbound = true,
                             ),
                             Link(
                                 type = "boardgamefamily",
                                 id = 136217,
                                 value = "Age of Industry Expansion: Belgium & USSR",
-                                inbound = true
+                                inbound = true,
                             ),
-                        )
+                        ),
                 )
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/ForumListResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/ForumListResponseTest.kt
@@ -59,7 +59,7 @@ class ForumListResponseTest {
                         "Post your game reviews in this forum.  <A href=\"/thread/59278\">Click here for help on writing game reviews.</A>",
                     numThreads = 65,
                     numPosts = 1603,
-                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 09:13:43 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 09:13:43 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696792,
@@ -69,7 +69,7 @@ class ForumListResponseTest {
                     description = "Post your session reports here.",
                     numThreads = 12,
                     numPosts = 99,
-                    lastPostDate = LocalDateTime.parse("Sun, 14 Jan 2024 22:56:08 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Sun, 14 Jan 2024 22:56:08 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696793,
@@ -79,7 +79,7 @@ class ForumListResponseTest {
                     description = "Post any related article to this game here.",
                     numThreads = 633,
                     numPosts = 9271,
-                    lastPostDate = LocalDateTime.parse("Wed, 24 Jan 2024 17:29:58 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Wed, 24 Jan 2024 17:29:58 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696794,
@@ -89,7 +89,7 @@ class ForumListResponseTest {
                     description = "Post any rules questions you have here.",
                     numThreads = 1096,
                     numPosts = 8191,
-                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 20:53:33 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 20:53:33 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696795,
@@ -99,7 +99,7 @@ class ForumListResponseTest {
                     description = "Post strategy and tactics articles here.",
                     numThreads = 119,
                     numPosts = 1853,
-                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 18:50:11 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 18:50:11 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696796,
@@ -109,7 +109,7 @@ class ForumListResponseTest {
                     description = "Post variants to the game rules here.",
                     numThreads = 146,
                     numPosts = 2335,
-                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 12:33:44 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Tue, 23 Jan 2024 12:33:44 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696797,
@@ -119,7 +119,7 @@ class ForumListResponseTest {
                     description = "Post time sensitive announcements here.",
                     numThreads = 19,
                     numPosts = 726,
-                    lastPostDate = LocalDateTime.parse("Fri, 19 Jan 2024 15:29:10 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Fri, 19 Jan 2024 15:29:10 +0000", formatter),
                 ),
                 ForumSummary(
                     id = 3696798,
@@ -129,7 +129,7 @@ class ForumListResponseTest {
                     description = "Post crowdfunding / preorder content here.",
                     numThreads = 0,
                     numPosts = 0,
-                    lastPostDate = null
+                    lastPostDate = null,
                 ),
                 ForumSummary(
                     id = 3696799,
@@ -139,7 +139,7 @@ class ForumListResponseTest {
                     description = "Run Play By Forum (PBF) games here.",
                     numThreads = 0,
                     numPosts = 0,
-                    lastPostDate = null
+                    lastPostDate = null,
                 ),
                 ForumSummary(
                     id = 3696800,
@@ -149,7 +149,7 @@ class ForumListResponseTest {
                     description = "Post here to find local gamers and to promote local events.",
                     numThreads = 12,
                     numPosts = 228,
-                    lastPostDate = LocalDateTime.parse("Mon, 22 Jan 2024 13:22:41 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Mon, 22 Jan 2024 13:22:41 +0000", formatter),
                 ),
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/ForumResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/ForumResponseTest.kt
@@ -60,7 +60,7 @@ class ForumResponseTest {
                     author = "Farouke",
                     numArticles = 11,
                     postDate = LocalDateTime.parse("Sun, 11 Feb 2024 13:15:58 +0000", formatter),
-                    lastPostDate = LocalDateTime.parse("Wed, 14 Feb 2024 22:44:14 +0000", formatter)
+                    lastPostDate = LocalDateTime.parse("Wed, 14 Feb 2024 22:44:14 +0000", formatter),
                 )
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/HotResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/HotResponseTest.kt
@@ -53,7 +53,7 @@ class HotResponseTest {
                     name = "John Company: Second Edition",
                     yearPublished = 2022,
                     thumbnail =
-                        "https://cf.geekdo-images.com/TAdE4z_bwAAjJlmPrkmKhA__thumb/img/pwgtQn8ArKjwBxk3bnDuIVAPWgU=/fit-in/200x150/filters:strip_icc()/pic6601629.jpg"
+                        "https://cf.geekdo-images.com/TAdE4z_bwAAjJlmPrkmKhA__thumb/img/pwgtQn8ArKjwBxk3bnDuIVAPWgU=/fit-in/200x150/filters:strip_icc()/pic6601629.jpg",
                 )
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/PlaysResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/PlaysResponseTest.kt
@@ -68,7 +68,7 @@ class PlaysResponseTest {
                     name = "Sid Meier's Civilization: The Board Game",
                     objectType = PlayThingType.THING,
                     objectId = 77130,
-                    subTypes = listOf(SubType(org.audux.bgg.common.SubType.BOARD_GAME))
+                    subTypes = listOf(SubType(org.audux.bgg.common.SubType.BOARD_GAME)),
                 )
             )
         assertThat(civGame.players)
@@ -81,7 +81,7 @@ class PlaysResponseTest {
                     new = false,
                     rating = 0.0,
                     win = true,
-                    color = "Purple"
+                    color = "Purple",
                 ),
                 Player(
                     username = "",
@@ -91,7 +91,7 @@ class PlaysResponseTest {
                     new = false,
                     rating = 0.0,
                     win = false,
-                    color = "Yellow"
+                    color = "Yellow",
                 ),
                 Player(
                     username = "",
@@ -101,7 +101,7 @@ class PlaysResponseTest {
                     color = "",
                     new = false,
                     rating = 0.0,
-                    win = false
+                    win = false,
                 ),
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/SearchResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/SearchResponseTest.kt
@@ -60,7 +60,7 @@ class SearchResponseTest {
                     id = 167159,
                     name = Name("Connect 4: My Little Pony", "primary"),
                     type = ThingType.BOARD_GAME,
-                    yearPublished = 2014
+                    yearPublished = 2014,
                 )
             )
     }

--- a/src/test/kotlin/org/audux/bgg/response/SitemapResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/SitemapResponseTest.kt
@@ -89,6 +89,6 @@ class SitemapResponseTest {
             location = location,
             changeFrequency = "daily",
             priority = 1.0,
-            lastModified = null
+            lastModified = null,
         )
 }

--- a/src/test/kotlin/org/audux/bgg/response/ThingsResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/ThingsResponseTest.kt
@@ -59,7 +59,7 @@ class ThingsResponseTest {
                 TestUtils.xml(
                     "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                 ),
-                Things::class.java
+                Things::class.java,
             )
         val thing = things.things[0]
         val encodedThing = Json.encodeToString(thing)
@@ -99,7 +99,7 @@ class ThingsResponseTest {
                 .containsExactly(
                     PlayerAgePoll::class.java,
                     LanguageDependencePoll::class.java,
-                    NumberOfPlayersPoll::class.java
+                    NumberOfPlayersPoll::class.java,
                 )
         }
 
@@ -119,13 +119,13 @@ class ThingsResponseTest {
                             listOf(
                                 PollSummaryResult(
                                     name = "bestwith",
-                                    value = "Best with 3–4 players"
+                                    value = "Best with 3–4 players",
                                 ),
                                 PollSummaryResult(
                                     name = "recommmendedwith",
-                                    value = "Recommended with 2–5 players"
-                                )
-                            )
+                                    value = "Recommended with 2–5 players",
+                                ),
+                            ),
                     )
                 )
         }
@@ -263,7 +263,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -287,7 +287,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -313,7 +313,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -349,7 +349,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -384,7 +384,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=396790&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -411,7 +411,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=307683&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -449,7 +449,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=307689&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -481,7 +481,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=140545&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -514,7 +514,7 @@ class ThingsResponseTest {
                     TestUtils.xml(
                         "thing?id=311654&stats=1&ratingcomments=1&versions=1&marketplace=1&videos=1"
                     ),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)
@@ -545,7 +545,7 @@ class ThingsResponseTest {
             val things =
                 mapper.readValue(
                     TestUtils.xml("thing?id=51651&stats=1&ratingcomments=1&videos=1&marketplace=1"),
-                    Things::class.java
+                    Things::class.java,
                 )
 
             assertThat(things.things).hasSize(1)

--- a/src/test/kotlin/org/audux/bgg/response/UserResponseTest.kt
+++ b/src/test/kotlin/org/audux/bgg/response/UserResponseTest.kt
@@ -39,7 +39,7 @@ class UserResponseTest {
         val user =
             mapper.readValue(
                 xml("user?name=Novaeux&buddies=1&hot=1&top=1&guilds=1&page=1&domain=boardgame"),
-                User::class.java
+                User::class.java,
             )
         val encodedUser = Json.encodeToString(user)
 
@@ -77,7 +77,7 @@ class UserResponseTest {
         val results =
             mapper.readValue(
                 xml("user?name=Novaeux&buddies=1&hot=1&top=1&guilds=1&page=1&domain=boardgame"),
-                User::class.java
+                User::class.java,
             )
 
         assertThat(results.name).isEqualTo("Novaeux")

--- a/src/test/kotlin/org/audux/bgg/util/TestUtils.kt
+++ b/src/test/kotlin/org/audux/bgg/util/TestUtils.kt
@@ -92,11 +92,15 @@ object TestUtils {
         respondOk("OK")
     }
 
+    fun instantResponse(): MockRequestHandleScope.(HttpRequestData) -> HttpResponseData = {
+        respondOk("OK")
+    }
+
     /** All data that is logged in a single [Logger.log] call. */
     data class LogWrite(
         val severity: Severity,
         val message: String,
         val tag: String,
-        val throwable: Throwable?
+        val throwable: Throwable?,
     )
 }


### PR DESCRIPTION
Changes: 
 * Renamed the RequestLimiter to ConcurrentRequestLimiter
 * Added a new plugin: RequestLimiter. 
   * The plugin prevents the client from making more than [BggClient.Configuration.requestsPerWindowLimit] requests in [BggClient.configuration.requestWindowSize].
   *  The configuration defaults to 60 requests per minute as this seems to be the limit imposed by BoardGameGeek.